### PR TITLE
DOC: computed property should be compared as a returning value

### DIFF
--- a/docs/api/mount/computed.md
+++ b/docs/api/mount/computed.md
@@ -33,5 +33,5 @@ import { mount } from 'avoriaz';
 import Foo from './Foo.vue';
 
 const wrapper = mount(Foo);
-expect(wrapper.computed().foo).to.equal('foo');
+expect(wrapper.computed().foo()).to.equal('foo');
 ```


### PR DESCRIPTION
In the previous example the value was compared to a function
reference.