### PR TITLE
Fix typo in simulate doc page. Should be Foo instead of ClickComponent

### DIFF
--- a/docs/api/mount/simulate.md
+++ b/docs/api/mount/simulate.md
@@ -14,7 +14,7 @@ import sinon from 'sinon';
 import Foo from './Foo';
 
 const clickHandler = sinon.stub();
-const wrapper = mount(ClickComponent, {
+const wrapper = mount(Foo, {
   propsData: { clickHandler },
 });
 


### PR DESCRIPTION
`ClickComponent` was not imported, but used. Changed it with the imported `Foo` component.