### PR TITLE
Allow key modifiers in simulate method

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -314,7 +314,26 @@ export default class Wrapper {
       throw new Error('wrapper.simulate() must be passed a string');
     }
 
-    const eventObject = new window.Event(type);
+    const modifiers = {
+      enter: 13,
+      tab: 9,
+      delete: 46,
+      esc: 27,
+      space: 32,
+      up: 38,
+      down: 40,
+      left: 37,
+      right: 39,
+    };
+
+    const event = type.split('.');
+
+    const eventObject = new window.Event(event[0]);
+
+    if (event.length === 2) {
+      eventObject.keyCode = modifiers[event[1]];
+    }
+
     this.element.dispatchEvent(eventObject);
     this.update();
   }

--- a/test/resources/components/event-components/KeydownWithModifierComponent.vue
+++ b/test/resources/components/event-components/KeydownWithModifierComponent.vue
@@ -1,0 +1,10 @@
+<template>
+	<input type="text" @keydown.enter="keydownHandler" />
+</template>
+
+<script>
+  export default{
+    name: 'KeyDownWithModifierComponent',
+    props: ['keydownHandler'],
+  };
+</script>

--- a/test/unit/specs/mount/simulate.spec.js
+++ b/test/unit/specs/mount/simulate.spec.js
@@ -2,6 +2,7 @@ import mount from '../../../../src/mount';
 import ClickComponent from '../../../resources/components/event-components/ClickComponent.vue';
 import ClickToggleComponent from '../../../resources/components/event-components/ClickToggleComponent.vue';
 import KeydownComponent from '../../../resources/components/event-components/KeydownComponent.vue';
+import KeydownWithModifier from '../../../resources/components/event-components/KeydownWithModifierComponent.vue';
 
 describe('simulate', () => {
   it('causes click handler to fire when wrapper.simulate("click") is called on a child node', () => {
@@ -31,6 +32,16 @@ describe('simulate', () => {
       propsData: { keydownHandler },
     });
     wrapper.simulate('keydown');
+
+    expect(keydownHandler).to.be.calledOnce;
+  });
+
+  it('causes keydown handler to fire when wrapper.simulate("keydown.enter") is fired on root node', () => {
+    const keydownHandler = sinon.stub();
+    const wrapper = mount(KeydownWithModifier, {
+      propsData: { keydownHandler },
+    });
+    wrapper.simulate('keydown.enter');
 
     expect(keydownHandler).to.be.calledOnce;
   });


### PR DESCRIPTION
Allow to pass events with key modifiers like `keyup.enter`. 

If a modifier is passed, the keyCode is added to the event.