### PR TITLE
support: render vue instance into document

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -91,6 +91,11 @@ export default class Wrapper {
     if (!this.isVueComponent) {
       throw new Error('wrapper.destroy() can only be called on a Vue instance');
     }
+
+    if (this.vm.$el.parentNode) {
+      this.vm.$el.parentNode.removeChild(this.vm.$el);
+    }
+
     this.vm.$destroy();
   }
 

--- a/src/mount.js
+++ b/src/mount.js
@@ -11,14 +11,22 @@ function createElem() {
 }
 
 export default function mount(component, options, mounted = false) {
-  const Constructor = Vue.extend(component);
-  const vm = new Constructor(options);
-
   let elem = null;
-  if (mounted) {
+  let mountOptions = options;
+  let mountedToDocument = mounted;
+
+  if (typeof options === 'boolean') {
+    mountedToDocument = options;
+    mountOptions = {};
+  }
+
+  if (mountedToDocument) {
     elem = createElem();
   }
+
+  const Constructor = Vue.extend(component);
+  const vm = new Constructor(mountOptions);
   vm.$mount(elem);
 
-  return new VueWrapper(vm, options);
+  return new VueWrapper(vm, mountOptions);
 }

--- a/src/mount.js
+++ b/src/mount.js
@@ -2,9 +2,23 @@ import Vue from './lib/vue';
 import './lib/matchesPolyfill';
 import VueWrapper from './VueWrapper';
 
-export default function mount(component, options) {
+function createElem() {
+  const elem = document.createElement('div');
+
+  document.body.appendChild(elem);
+
+  return elem;
+}
+
+export default function mount(component, options, mounted = false) {
   const Constructor = Vue.extend(component);
   const vm = new Constructor(options);
-  vm.$mount();
+
+  let elem = null;
+  if (mounted) {
+    elem = createElem();
+  }
+  vm.$mount(elem);
+
   return new VueWrapper(vm, options);
 }

--- a/test/unit/specs/mount/destroy.spec.js
+++ b/test/unit/specs/mount/destroy.spec.js
@@ -15,6 +15,15 @@ describe('destory', () => {
     expect(expect(func).to.have.been.calledOnce);
   });
 
+  it('remove element from document.body', () => {
+    const compiled = compileToFunctions('<div></div>');
+    const wrapper = mount(compiled, true);
+    expect(wrapper.vm.$el.parentNode).to.equal(document.body);
+
+    wrapper.destroy();
+    expect(wrapper.vm.$el.parentNode).to.be.null;
+  });
+
   it('throws an error if node is not a Vue instance', () => {
     const message = 'wrapper.destroy() can only be called on a Vue instance';
     const compiled = compileToFunctions('<div><p></p></div>');


### PR DESCRIPTION
Support for testing browser-based Components

if `mount` called with third parameter
```javascript
mount(Foo, {
  propsData: {}
}, true);
```
Foo will be render into document

Or Simply
```javascript
mount(Foo, true);
```