### PR TITLE
pass 'options' to Vue.use()

### DIFF
--- a/docs/api/use.md
+++ b/docs/api/use.md
@@ -8,6 +8,8 @@ A wrapper around [Vue.use](https://vuejs.org/v2/api/#Vue-use)
 
 `plugin` (`Object`|`Function`): If the plugin is an Object, it must expose an install method. If it is a function itself, it will be treated as the install method.
 
+`options` (`Object`) [optional]: Options for the plugin
+
 ### Example
 
 ```js

--- a/src/use.js
+++ b/src/use.js
@@ -1,5 +1,5 @@
 import Vue from './lib/vue';
 
-export default function (plugin) {
-  Vue.use(plugin);
+export default function (plugin, options) {
+  Vue.use(plugin, options);
 }


### PR DESCRIPTION
Vue.use() takes an optional second parameter; this changes just passes that through.

See https://github.com/vuejs/vue/blob/master/test/unit/features/global-api/use.spec.js