### PR TITLE
Align gitbook docs with Vue styling

### DIFF
--- a/docs/book.json
+++ b/docs/book.json
@@ -1,7 +1,22 @@
 {
-  "gitbook": "3.x.x",
+  "gitbook": ">3.0.0",
   "structure": {
     "summary": "SUMMARY.md"
   },
-  "plugins": ["prism", "-highlight"]
+  "plugins": ["edit-link", "prism", "theme-vuejs@git+https://github.com/pearofducks/gitbook-plugin-theme-vuejs.git", "-fontsettings", "-highlight", "github"],
+  "pluginsConfig": {
+    "edit-link": {
+      "base": "https://github.com/eddyerburgh/avoriaz/tree/master/docs",
+      "label": "Edit This Page"
+    },
+    "github": {
+      "url": "https://github.com/eddyerburgh/avoriaz"
+    }
+  },
+  "links": {
+    "sharing": {
+      "facebook": false,
+      "twitter": false
+    }
+  }
 }


### PR DESCRIPTION
- Moves the documentation styling to what Vuex and vue-router currently use
  - Changes theme to one based on vuejs.org
  - Removes some social media buttons (that weren't setup)
  - Adds an "Edit this page" link at the top that links directly to the page in the GitHub repo