### PR TITLE
per issue 51

### DIFF
--- a/test/resources/components/table/Row.vue
+++ b/test/resources/components/table/Row.vue
@@ -1,0 +1,11 @@
+<template>
+  <tr>
+    <td>contents</td>
+  </tr>
+</template>
+
+<script>
+  export default{
+    name: 'Row',
+  };
+</script>

--- a/test/resources/components/table/Table.vue
+++ b/test/resources/components/table/Table.vue
@@ -1,0 +1,18 @@
+<template>
+  <table>
+    <tbody>
+    <Row></Row>
+    </tbody>
+  </table>
+</template>
+
+<script>
+  import Row from './Row.vue';
+
+  export default{
+    name: 'Table',
+    components: {
+      Row,
+    },
+  };
+</script>

--- a/test/unit/specs/mount.spec.js
+++ b/test/unit/specs/mount.spec.js
@@ -3,6 +3,8 @@ import mount from '../../../src/mount';
 import ClickComponent from '../../resources/components/event-components/ClickComponent.vue';
 import SlotChild from '../../resources/components/slots/SlotChild.vue';
 import MixinComponent from '../../resources/components/mixins/MixinComponent.vue';
+import Table from '../../resources/components/table/Table.vue';
+import Row from '../../resources/components/table/Row.vue';
 
 describe('mount', () => {
   it('returns new VueWrapper with mounted Vue instance if no options are passed', () => {
@@ -104,5 +106,17 @@ describe('mount', () => {
     MixinComponent.methods.someMethod = sinon.stub();
     mount(MixinComponent);
     expect(MixinComponent.methods.someMethod.callCount).to.equal(1);
+  });
+
+  it('mounts tables and sub components', () => {
+    const wrapper = mount(Table);
+    expect(wrapper.html()).to.equal('<table><tbody><tr><td>contents</td></tr></tbody></table>');
+    expect(wrapper.find('td').length).to.be.greaterThan(0);
+  });
+
+  it('mounts sub components of tables', () => {
+    const wrapper = mount(Row);
+    expect(wrapper.html()).to.equal('<tr><td>contents</td></tr>');
+    expect(wrapper.find('td').length).to.be.greaterThan(0);
   });
 });


### PR DESCRIPTION
This adds two passing tests that show that avoriaz correctly handles, for the tested toolchain, the mounting of components with root elements that are portions of tables, and that the correct html is seen via the .html() call on a wrapper.