### PR TITLE
Add first method to Wrapper

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,6 +8,7 @@
     * [data](/api/mount/data.md)
     * [destroy](/api/mount/destroy.md)
     * [find](/api/mount/find.md)
+    * [first](/api/mount/first.md)
     * [hasAttribute](/api/mount/hasAttribute.md)
     * [hasClass](/api/mount/hasClass.md)
     * [hasStyle](/api/mount/hasStyle.md)

--- a/docs/api/mount/first.md
+++ b/docs/api/mount/first.md
@@ -1,0 +1,22 @@
+# find(selector)
+
+Returns a wrapper of DOM node or Vue component. Use any valid [avoriaz selector](/api/selectors.md).
+
+### Arguments
+
+`selector` (`String`|`Component`): a CSS selector ('#id', '.class-name', 'tag') or a Vue component. See [selectors](/api/selectors.md).
+
+### Returns
+
+(`Object`): returns the first wrapper matching selector. Vue component wrappers have extra methods ([computed](/api/mount/computed.md), [data](/api/mount/data.md), [methods](/api/mount/methods.md), [propsData](/api/mount/propsData.md)). To check if a wrapper is a Vue component wrapper, use wrapper.isVueComponent.
+
+### Example
+
+```js
+import { mount } from 'avoriaz';
+import Foo from './Foo.vue';
+
+const wrapper = mount(Foo);
+const div = wrapper.first('div');
+expect(div.is('div')).to.equal(true);
+```

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -147,6 +147,22 @@ export default class Wrapper {
   }
 
   /**
+   * Returns the first node in the mount tree of the current wrapper that matches the provided selector.
+   *
+   * @param {String|Object} selector
+   * @returns {VueWrapper}
+   */
+  first(selector) {
+    const nodes = this.find(selector);
+
+    if (!nodes.length) {
+      throw new Error('wrapper.first() has no matches with the given selector');
+    }
+
+    return nodes[0];
+  }
+
+  /**
    * Checks if wrapper has an attribute with matching value
    *
    * @param {String} attribute - attribute to assert

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -147,7 +147,7 @@ export default class Wrapper {
   }
 
   /**
-   * Returns the first node in the mount tree of the current wrapper that matches the provided selector.
+   * Returns the first node that matches the provided selector.
    *
    * @param {String|Object} selector
    * @returns {VueWrapper}

--- a/test/unit/specs/wrapper/first.spec.js
+++ b/test/unit/specs/wrapper/first.spec.js
@@ -1,0 +1,26 @@
+import { compileToFunctions } from 'vue-template-compiler';
+import mount from '../../../../src/mount';
+import Wrapper from '../../../../src/Wrapper';
+
+describe('first', () => {
+  it('returns a Wrapper instance matching tag selector passed', () => {
+    const compiled = compileToFunctions('<div><p></p><p></p></div>');
+    const wrapper = mount(compiled);
+    const div = wrapper.first('p');
+    expect(div).to.be.an.instanceOf(Wrapper);
+  });
+
+  it('returns the first Wrapper matching tag selector passed', () => {
+    const compiled = compileToFunctions('<div><p class="active"></p><p></p></div>');
+    const wrapper = mount(compiled);
+    const div = wrapper.first('p');
+    expect(div.hasClass('active')).to.be.true;
+  });
+
+  it('throws an error when passed selector has no matches', () => {
+    const compiled = compileToFunctions('<div><a></a></div>');
+    const wrapper = mount(compiled);
+    const message = 'wrapper.first() has no matches with the given selector';
+    expect(() => wrapper.first('p')).to.throw(Error, message);
+  });
+});


### PR DESCRIPTION
This PR adds the abilty to use `wrapper.first('p')`  as a syntax sugar for `wrapper.find('p')[0]`.

It returns the first ocurrence when found and throws an error if not.

I wrote some tests that proves the functionality and relies in the existing tests for find method for all the use cases.

If you find something weird let me know
