### PR TITLE
Allow one to define children for functional components

### DIFF
--- a/docs/api/mount/README.md
+++ b/docs/api/mount/README.md
@@ -12,6 +12,8 @@ Create a fully rendered Vue component. Returns a wrapper that includes methods t
 
 `options.context` (`Object`): Context option to be passed to a functional component
 
+`options.children` (`Array`): Array of children to be passed to a functional component
+
 `options.slots` (`Object`): Render component with slots.
 
 `options.slots.default` (`Array[Component]|Component`): Default slot object to render, can be a Vue component or array of Vue components

--- a/src/mount.js
+++ b/src/mount.js
@@ -37,7 +37,7 @@ export default function mount(component, options = {}) {
     const clonedComponent = cloneDeep(component);
     component = { // eslint-disable-line no-param-reassign
       render(h) {
-        return h(clonedComponent, options.context);
+        return h(clonedComponent, options.context, options.children);
       },
     };
   }

--- a/test/unit/specs/mount.spec.js
+++ b/test/unit/specs/mount.spec.js
@@ -6,6 +6,7 @@ import SlotChild from '../../resources/components/slots/SlotChild.vue';
 import MixinComponent from '../../resources/components/mixins/MixinComponent.vue';
 import Table from '../../resources/components/table/Table.vue';
 import Row from '../../resources/components/table/Row.vue';
+import UnnamedChild from '../../resources/components/unnamed-components/UnnamedChild.vue';
 
 describe('mount', () => {
   it('returns new VueWrapper with mounted Vue instance if no options are passed', () => {
@@ -167,5 +168,28 @@ describe('mount', () => {
     expect(wrapper.vm.globalProp).to.equal(true);
     const freshWrapper = mount(ClickComponent);
     expect(freshWrapper.vm.globalProp).to.be.undefined;
+  });
+
+  it('mounts functional component with children when passed children array', () => {
+    const Component = {
+      functional: true,
+      render(h, { children }) {
+        return h('div', children);
+      },
+      name: 'common',
+    };
+
+    const context = {};
+
+    const child = mount(UnnamedChild);
+    const children = [
+      child.vNode,
+      'hello',
+    ];
+
+    const wrapper = mount(Component, { context, children });
+
+    expect(wrapper.is(Component)).to.equal(true);
+    expect(wrapper.isEmpty()).to.equal(false);
   });
 });


### PR DESCRIPTION
Without this change there's no way of defining the children of a functional component. Say you have a component like this (contrived example)

```javascript
export default {
  functional: true,
  render (h, { children }) {
    children[0].text = children[0].text.toUpperCase()
    return h('span', children)
  }
}
```

Now you can do this

```javascript
const wrapper = mount(FunctionalComponent, {
  context: {},
  children: ['this text should be uppercase']
}
```