### PR TITLE
getAttribute() & hasAttribute() & getProp()

### DIFF
--- a/docs/api/mount/getAttribute.md
+++ b/docs/api/mount/getAttribute.md
@@ -1,0 +1,37 @@
+# getAttribute(attribute)
+
+Returns value of specified attribute of wrapper DOM node
+
+### Arguments
+
+`attribute` (`String`): attribute name to assert value of.
+
+### Returns
+
+(`String`): value of specified attribute if the attribute exists in the wrapper DOM node, empty string otherwise.
+
+## Example
+
+`Foo.vue`
+
+```js
+<template lang="html">
+    <div id="foo"></div>
+</template>
+
+<script>
+export default {
+    name: 'foo'
+}
+</script>
+```
+
+`Foo.spec.js`
+
+```js
+import { mount } from 'avoriaz';
+import Foo from './Foo.vue';
+
+const wrapper = mount(Foo);
+expect(wrapper.getAttribute('id')).to.equal('foo');
+```

--- a/docs/api/mount/getProp.md
+++ b/docs/api/mount/getProp.md
@@ -1,6 +1,6 @@
-# propsData()
+# getProp()
 
-Returns value of specified prop of Vue instances. Can only be called on a Vue component wrapper.
+Returns value of specified prop of Vue instance. Can only be called on a Vue component wrapper.
 
 ### Returns
 

--- a/docs/api/mount/getProp.md
+++ b/docs/api/mount/getProp.md
@@ -1,0 +1,18 @@
+# propsData()
+
+Returns value of specified prop of Vue instances. Can only be called on a Vue component wrapper.
+
+### Returns
+
+(`Any`): value of specified prop.
+
+### Example
+
+```js
+import { mount } from 'avoriaz';
+import Foo from './Foo.vue';
+
+const foo = 'bar';
+const wrapper = mount(Foo, {propsData:{foo}});
+expect(wrapper.getProp('foo')).to.equal(foo);
+```

--- a/docs/api/mount/hasAttribute.md
+++ b/docs/api/mount/hasAttribute.md
@@ -1,17 +1,14 @@
-# hasAttribute(attribute, value)
+# hasAttribute(attribute)
 
-Check if wrapper DOM node has attribute matching value
+Check if wrapper DOM node has specified attribute
 
 ### Arguments
 
-`attribute` (`String`): attribute name to assert value of.
-
-`value` (`String`): the value attribute should hold.
+`attribute` (`String`): attribute name to assert.
 
 ### Returns
 
-(`Boolean`): `true` if element contains attribute
-with matching value, `false` otherwise.
+(`Boolean`): `true` if element contains specified attribute, `false` otherwise.
 
 ## Example
 
@@ -36,5 +33,5 @@ import { mount } from 'avoriaz';
 import Foo from './Foo.vue';
 
 const wrapper = mount(Foo);
-expect(wrapper.hasAttribute('id', 'foo')).to.equal(true);
+expect(wrapper.hasAttribute('id')).to.equal(true);
 ```

--- a/flow/wrapper.flow.js
+++ b/flow/wrapper.flow.js
@@ -8,6 +8,7 @@ declare interface WrapperInterface { // eslint-disable-line no-undef
     data(): Object;
     destroy(): void;
     getAttribute(attribute: string): string;
+    getProp(propName: string): any;
     hasAttribute(attribute: string): boolean;
     hasClass(className: string): boolean;
     hasStyle(style: string, value: string): boolean;

--- a/flow/wrapper.flow.js
+++ b/flow/wrapper.flow.js
@@ -7,7 +7,8 @@ declare interface WrapperInterface { // eslint-disable-line no-undef
     contains(selector: Selector): boolean;
     data(): Object;
     destroy(): void;
-    hasAttribute(attribute: string, value: string): boolean;
+    getAttribute(attribute: string): string;
+    hasAttribute(attribute: string): boolean;
     hasClass(className: string): boolean;
     hasStyle(style: string, value: string): boolean;
     find(selector: Selector): WrapperType;

--- a/flow/wrapper.flow.js
+++ b/flow/wrapper.flow.js
@@ -9,7 +9,7 @@ declare interface WrapperInterface { // eslint-disable-line no-undef
     destroy(): void;
     getAttribute(attribute: string): string;
     getProp(propName: string): any;
-    hasAttribute(attribute: string): boolean;
+    hasAttribute(attribute: string, value: ?string): boolean;
     hasClass(className: string): boolean;
     hasStyle(style: string, value: string): boolean;
     find(selector: Selector): WrapperType;

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -178,12 +178,22 @@ export default class Wrapper implements WrapperInterface {
    * @param {String} attribute - attribute to assert
    * @returns {Boolean}
    */
-  hasAttribute(attribute: string) {
+  hasAttribute(attribute: string, value?: string) {
     if (typeof attribute !== 'string') {
-      error('wrapper.hasAttribute() must be passed a string');
+      error('wrapper.hasAttribute() must be passed attribute as a string');
     }
 
-    return this.element.hasAttribute(attribute);
+    if (arguments.length === 1) {
+      return this.element.hasAttribute(attribute);
+    }
+
+    if (typeof value !== 'string') {
+      error('wrapper.hasAttribute() must be passed value as a string');
+    }
+
+    warn('wrapper.hasAttribute(attribute, value) is deprecated in place of a new syntax and the old syntax will be removed from future versions. Instead, we encourage you to use getAttribute(attribute) === value to assert attribute value for better error report. For detailed information, see: https://github.com/eddyerburgh/avoriaz/issues/100');
+
+    return this.element.getAttribute(attribute) === value;
   }
 
   /**

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -133,22 +133,35 @@ export default class Wrapper implements WrapperInterface {
   }
 
   /**
-   * Checks if wrapper has an attribute with matching value
+   * Returns value of specified attribute of wrapper
    *
    * @param {String} attribute - attribute to assert
-   * @param {String} value - value attribute should contain
+   * @returns {String}
+   */
+  getAttribute(attribute: string) {
+    if (typeof attribute !== 'string') {
+      error('wrapper.getAttribute() must be passed a string');
+    }
+
+    if (!this.hasAttribute(attribute)) {
+      error(`wrapper has no attribute called ${attribute}`);
+    }
+
+    return this.element.getAttribute(attribute);
+  }
+
+  /**
+   * Asserts wrapper has an attribute
+   *
+   * @param {String} attribute - attribute to assert
    * @returns {Boolean}
    */
-  hasAttribute(attribute: string, value: string) {
+  hasAttribute(attribute: string) {
     if (typeof attribute !== 'string') {
-      error('wrapper.hasAttribute() must be passed attribute as a string');
+      error('wrapper.hasAttribute() must be passed a string');
     }
 
-    if (typeof value !== 'string') {
-      error('wrapper.hasAttribute() must be passed value as a string');
-    }
-
-    return this.element.getAttribute(attribute) === value;
+    return this.element.hasAttribute(attribute);
   }
 
   /**

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -151,6 +151,28 @@ export default class Wrapper implements WrapperInterface {
   }
 
   /**
+   * Returns prop value of a Vue instance
+   *
+   * @param {String} propName - prop name to assert
+   * @returns {*}
+   */
+  getProp(propName: string) {
+    if (!this.isVueComponent) {
+      error('wrapper.getProp() can only be called on a Vue instance');
+    }
+
+    if (typeof propName !== 'string') {
+      error('wrapper.getProp() must be passed a string');
+    }
+
+    const propValue = this.vm.$props[propName];
+    if (typeof propValue === 'function') {
+      warn('functions returned by getProp() will not have this bound to the vue instance. Calling a propsData function that uses this will result in an error. You can access propsData functions by using the vue instance. e.g. to call a method function named propsDataFunc, call wrapper.vm.$props.propsDataFunc(). See https://github.com/eddyerburgh/avoriaz/issues/15');
+    }
+    return propValue;
+  }
+
+  /**
    * Asserts wrapper has an attribute
    *
    * @param {String} attribute - attribute to assert

--- a/test/unit/specs/wrapper/getAttribute.spec.js
+++ b/test/unit/specs/wrapper/getAttribute.spec.js
@@ -1,32 +1,33 @@
 import { compileToFunctions } from 'vue-template-compiler';
 import mount from '../../../../src/mount';
 
-describe('hasAttribute', () => {
-  it('returns true if wrapper contains attribute with value', () => {
+describe('getAttribute', () => {
+  it('returns attribute value if wrapper contains attribute with value', () => {
     const attribute = 'attribute';
     const value = 'value';
     const compiled = compileToFunctions(`<div ${attribute}=${value}></div>`);
     const wrapper = mount(compiled);
-    expect(wrapper.hasAttribute(attribute)).to.equal(true);
+    expect(wrapper.getAttribute(attribute)).to.equal(value);
   });
 
-  it('returns true if wrapper contains attribute without value', () => {
+  it('returns empty string if wrapper contains attribute without value', () => {
     const attribute = 'attribute';
     const compiled = compileToFunctions(`<div ${attribute}></div>`);
     const wrapper = mount(compiled);
-    expect(wrapper.hasAttribute(attribute)).to.equal(true);
+    expect(wrapper.getAttribute(attribute)).to.equal('');
   });
 
-  it('returns false if wrapper does not contain attribute', () => {
+  it('throws an error if wrapper does not contain attribute', () => {
     const compiled = compileToFunctions('<div />');
     const wrapper = mount(compiled);
-    expect(wrapper.hasAttribute('attribute')).to.equal(false);
+    const message = 'wrapper has no attribute called attribute';
+    expect(() => wrapper.getAttribute('attribute')).to.throw(Error, message);
   });
 
   it('throws an error if attribute is not a string', () => {
     const compiled = compileToFunctions('<div />');
     const wrapper = mount(compiled);
-    const message = 'wrapper.hasAttribute() must be passed a string';
-    expect(() => wrapper.hasAttribute(undefined)).to.throw(Error, message);
+    const message = 'wrapper.getAttribute() must be passed a string';
+    expect(() => wrapper.getAttribute(undefined)).to.throw(Error, message);
   });
 });

--- a/test/unit/specs/wrapper/getProp.spec.js
+++ b/test/unit/specs/wrapper/getProp.spec.js
@@ -1,0 +1,45 @@
+import { compileToFunctions } from 'vue-template-compiler';
+import mount from '../../../../src/mount';
+import PropsComponent from '../../../resources/components/data-components/PropsComponent.vue';
+
+describe('propsData', () => {
+  beforeEach(() => {
+    sinon.spy(console, 'warn');
+  });
+
+  afterEach(() => {
+    console.warn.restore(); // eslint-disable-line no-console
+  });
+
+
+  it('returns prop value of the Vue instance', () => {
+    const propsData = {
+      prop1: 'prop value',
+      prop2: () => 'prop value',
+    };
+    const wrapper = mount(PropsComponent, { propsData });
+    const prop1 = wrapper.getProp('prop1');
+    const prop2 = wrapper.getProp('prop2');
+    expect(prop1).to.equal(propsData.prop1);
+    expect(prop2).to.equal(propsData.prop2);
+  });
+
+  it('throws an error if node is not a Vue instance', () => {
+    const message = 'wrapper.getProp() can only be called on a Vue instance';
+    const compiled = compileToFunctions('<div><p></p></div>');
+    const wrapper = mount(compiled);
+    const input = wrapper.find('p')[0];
+    expect(() => input.getProp('propName')).throw(Error, message);
+  });
+
+  it('calls console.warn with information on unbound this', () => {
+    const expectedText = '[avoriaz] WARN: functions returned by getProp() will not have this bound to the vue instance. Calling a propsData function that uses this will result in an error. You can access propsData functions by using the vue instance. e.g. to call a method function named propsDataFunc, call wrapper.vm.$props.propsDataFunc(). See https://github.com/eddyerburgh/avoriaz/issues/15';
+    const wrapper = mount(PropsComponent, {
+      propsData: {
+        prop1() {},
+      },
+    });
+    wrapper.getProp('prop1');
+    expect(console.warn).to.be.calledWith(expectedText); // eslint-disable-line no-console
+  });
+});

--- a/test/unit/specs/wrapper/hasAttribute.spec.js
+++ b/test/unit/specs/wrapper/hasAttribute.spec.js
@@ -2,31 +2,81 @@ import { compileToFunctions } from 'vue-template-compiler';
 import mount from '../../../../src/mount';
 
 describe('hasAttribute', () => {
-  it('returns true if wrapper contains attribute with value', () => {
-    const attribute = 'attribute';
-    const value = 'value';
-    const compiled = compileToFunctions(`<div ${attribute}=${value}></div>`);
-    const wrapper = mount(compiled);
-    expect(wrapper.hasAttribute(attribute)).to.equal(true);
+  describe('hasAttribute(attribute, value) - old syntax should still work', () => {
+    // https://github.com/eddyerburgh/avoriaz/pull/101#discussion_r132471262
+
+    beforeEach(() => {
+      sinon.spy(console, 'warn');
+    });
+
+    afterEach(() => {
+      console.warn.restore(); // eslint-disable-line no-console
+    });
+
+    it('returns true if wrapper contains attribute matching value', () => {
+      const attribute = 'attribute';
+      const value = 'value';
+      const compiled = compileToFunctions(`<div ${attribute}=${value}></div>`);
+      const wrapper = mount(compiled);
+      expect(wrapper.hasAttribute(attribute, value)).to.equal(true);
+    });
+
+    it('returns false if wrapper does not contain attribute', () => {
+      const compiled = compileToFunctions('<div />');
+      const wrapper = mount(compiled);
+      expect(wrapper.hasAttribute('attribute', 'value')).to.equal(false);
+    });
+
+    it('throws an error if attribute is not a string', () => {
+      const compiled = compileToFunctions('<div />');
+      const wrapper = mount(compiled);
+      const message = 'wrapper.hasAttribute() must be passed attribute as a string';
+      expect(() => wrapper.hasAttribute(undefined, 'value')).to.throw(Error, message);
+    });
+
+    it('throws an error if value is not a string', () => {
+      const compiled = compileToFunctions('<div />');
+      const wrapper = mount(compiled);
+      const message = 'wrapper.hasAttribute() must be passed value as a string';
+      expect(() => wrapper.hasAttribute('attribute', undefined)).to.throw(Error, message);
+    });
+
+    it('calls console.warn with information on old syntax being deprecated', () => {
+      const expectedText = '[avoriaz] WARN: wrapper.hasAttribute(attribute, value) is deprecated in place of a new syntax and the old syntax will be removed from future versions. Instead, we encourage you to use getAttribute(attribute) === value to assert attribute value for better error report. For detailed information, see: https://github.com/eddyerburgh/avoriaz/issues/100';
+      const compiled = compileToFunctions('<div />');
+      const wrapper = mount(compiled);
+      wrapper.hasAttribute('attribute', 'value');
+      expect(console.warn).to.be.calledWith(expectedText); // eslint-disable-line no-console
+    });
   });
 
-  it('returns true if wrapper contains attribute without value', () => {
-    const attribute = 'attribute';
-    const compiled = compileToFunctions(`<div ${attribute}></div>`);
-    const wrapper = mount(compiled);
-    expect(wrapper.hasAttribute(attribute)).to.equal(true);
-  });
+  describe('hasAttribute(attribute) - new syntax', () => {
+    it('returns true if wrapper contains attribute with value', () => {
+      const attribute = 'attribute';
+      const value = 'value';
+      const compiled = compileToFunctions(`<div ${attribute}=${value}></div>`);
+      const wrapper = mount(compiled);
+      expect(wrapper.hasAttribute(attribute)).to.equal(true);
+    });
 
-  it('returns false if wrapper does not contain attribute', () => {
-    const compiled = compileToFunctions('<div />');
-    const wrapper = mount(compiled);
-    expect(wrapper.hasAttribute('attribute')).to.equal(false);
-  });
+    it('returns true if wrapper contains attribute without value', () => {
+      const attribute = 'attribute';
+      const compiled = compileToFunctions(`<div ${attribute}></div>`);
+      const wrapper = mount(compiled);
+      expect(wrapper.hasAttribute(attribute)).to.equal(true);
+    });
 
-  it('throws an error if attribute is not a string', () => {
-    const compiled = compileToFunctions('<div />');
-    const wrapper = mount(compiled);
-    const message = 'wrapper.hasAttribute() must be passed a string';
-    expect(() => wrapper.hasAttribute(undefined)).to.throw(Error, message);
+    it('returns false if wrapper does not contain attribute', () => {
+      const compiled = compileToFunctions('<div />');
+      const wrapper = mount(compiled);
+      expect(wrapper.hasAttribute('attribute')).to.equal(false);
+    });
+
+    it('throws an error if attribute is not a string', () => {
+      const compiled = compileToFunctions('<div />');
+      const wrapper = mount(compiled);
+      const message = 'wrapper.hasAttribute() must be passed attribute as a string';
+      expect(() => wrapper.hasAttribute(undefined)).to.throw(Error, message);
+    });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -41,7 +41,7 @@ interface Wrapper {
     destroy(): void;
     getAttribute(attribute: string): string;
     getProp(propName: string): any;
-    hasAttribute(attribute: string): boolean;
+    hasAttribute(attribute: string, value?: string): boolean;
     hasClass(className: string): boolean;
     hasStyle(style: string, value: string): boolean;
     find(selector: Selector): Wrapper[];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,7 +39,8 @@ interface Wrapper {
     contains(selector: Selector): boolean;
     data(): object;
     destroy(): void;
-    hasAttribute(attribute: string, value: any): boolean;
+    getAttribute(attribute: string): string;
+    hasAttribute(attribute: string): boolean;
     hasClass(className: string): boolean;
     hasStyle(style: string, value: string): boolean;
     find(selector: Selector): Wrapper[];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,6 +40,7 @@ interface Wrapper {
     data(): object;
     destroy(): void;
     getAttribute(attribute: string): string;
+    getProp(propName: string): any;
     hasAttribute(attribute: string): boolean;
     hasClass(className: string): boolean;
     hasStyle(style: string, value: string): boolean;

--- a/types/test/mount.spec.ts
+++ b/types/test/mount.spec.ts
@@ -50,7 +50,8 @@ const wrapper = mount(ClassComponent);
 
 wrapper.contains("hello");
 wrapper.destroy();
-wrapper.hasAttribute("attr", 1);
+wrapper.hasAttribute("attr");
+wrapper.hasAttribute("attr", "value");
 wrapper.hasClass("className");
 wrapper.hasStyle("color", "red");
 wrapper.find("div");


### PR DESCRIPTION
Closes #100. 
Added `getAttribute()` & `getProp()` methods and changed behavior of `hasAttribute()` method.