### PR TITLE
Fixes broken links in documentation to API

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,3 +1,3 @@
-## [mount](/docs/api/mount/README.md)
-## [shallow](/docs/api/shallow/README.md)
-## [selectors](/docs/api/selectors.md)
+## [mount](/docs/api/mount)
+## [shallow](/docs/api/shallow)
+## [selectors](/docs/api/selectors.html)


### PR DESCRIPTION
Hello :wave:

I've discovered that the links on [API overview](https://eddyerburgh.gitbooks.io/avoriaz/content/api/) are linking to `README.md` files which don't seem to exist on the frontend. This fixes it.

For some strange reason the link to `selectors` requires an `.html` postfix.