### PR TITLE
[FIX] isEmpty to return true if contains empty slot 

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -308,7 +308,7 @@ export default class Wrapper implements WrapperInterface {
    * @returns {Boolean}
    */
   isEmpty() {
-    return this.vNode.children === undefined;
+    return this.vNode.children === undefined || this.vNode.children.length === 0;
   }
 
   /**

--- a/test/unit/specs/wrapper/isEmpty.spec.js
+++ b/test/unit/specs/wrapper/isEmpty.spec.js
@@ -9,6 +9,13 @@ describe('isEmpty', () => {
     expect(wrapper.isEmpty()).to.equal(true);
   });
 
+  it('returns true contains empty slot', () => {
+    const compiled = compileToFunctions('<div><slot></slot></div>');
+    const wrapper = mount(compiled);
+
+    expect(wrapper.isEmpty()).to.equal(true);
+  });
+
   it('returns false if node contains other nodes', () => {
     const compiled = compileToFunctions('<div><p /></div>');
     const wrapper = mount(compiled);


### PR DESCRIPTION
Mounting element with slot with no content sets vNode children to [], which makes isEmpty return false (currently checks only for undefined). 

There's also a similar issue for v-if as well, it adds comments node even if the element isn't rendered but I didn't try to fix that issue here. Happy to add this if you think it's worthwhile? (i.e. loop over all nodes in children and exclude any comment elements, then check for undefined or [])

FYI, first PR so be gentle :)