### PR TITLE
add ability to render default slot in global components

### DIFF
--- a/docs/api/shallow/README.md
+++ b/docs/api/shallow/README.md
@@ -20,6 +20,8 @@ Create a Vue component with all child components stubbed. Returns a wrapper that
 
 `options.slots.name` (`Array[Component]|Component|Wrapper|Array[Wrapper]`): Named slots. i.e. slots.name will match a <slot name="name" />, can be a Vue component or array of Vue components
 
+`options.renderDefaultSlot` (`Boolean`): Render global components with default slot.
+
 `options.globals` (`Object`): Add globals to Vue instance.
 
 `options.provide` (`Object`): Provide values to Vue instance

--- a/flow/options.flow.js
+++ b/flow/options.flow.js
@@ -10,5 +10,6 @@ declare type MountOptions = { // eslint-disable-line no-undef
     children?: Array<string | Component>,
     slots?: Slots,
     globals?: Object,
-    instance?: Component
+    instance?: Component,
+    renderDefaultSlot?: boolean,
 }

--- a/src/lib/stub-components.js
+++ b/src/lib/stub-components.js
@@ -37,7 +37,7 @@ function extractCoreProps(component) {
     style: component.style,
   };
 }
-export function replaceGlobalComponents(instance, component) {
+export function replaceGlobalComponents(instance, component, renderDefaultSlot) {
   Object.keys(instance.options.components).forEach((c) => {
     if (isRequired(c)) {
       return;
@@ -46,7 +46,10 @@ export function replaceGlobalComponents(instance, component) {
       component.components = {}; // eslint-disable-line no-param-reassign
     }
     component.components[c] = { // eslint-disable-line no-param-reassign
-      render: () => {},
+      render(h) {
+        if (renderDefaultSlot) return h('div', this.$slots.default);
+        return {};
+      },
       ...extractCoreProps(instance.options.components[c]),
     };
     delete component.components[c]._Ctor; // eslint-disable-line no-param-reassign

--- a/src/shallow.js
+++ b/src/shallow.js
@@ -10,8 +10,8 @@ export default function shallow(component: Component, options: MountOptions) {
   if (clonedComponent.components) {
     replaceComponents(clonedComponent);
   }
-
-  replaceGlobalComponents(Vue, clonedComponent);
+  const renderDefaultSlot = options ? options.renderDefaultSlot : false;
+  replaceGlobalComponents(Vue, clonedComponent, renderDefaultSlot);
 
   return mount(clonedComponent, options);
 }

--- a/test/resources/components/slots/Global.vue
+++ b/test/resources/components/slots/Global.vue
@@ -1,0 +1,16 @@
+<template>
+    <div>
+        <div id="container">
+            <global-component>HELLO</global-component>
+        </div>
+    </div>
+</template>
+<script>
+    import Vue from 'vue';
+
+    Vue.component('global-component', { render: h => h('div', this.$slots.default) });
+
+    export default {
+      name: 'global-slots',
+    };
+</script>

--- a/test/unit/specs/shallow.spec.js
+++ b/test/unit/specs/shallow.spec.js
@@ -8,6 +8,7 @@ import ChildProps from '../../resources/components/data-components/ChildProps.vu
 import Submit from '../../resources/components/form/Submit.vue';
 import LogMountedParent from '../../resources/components/lifecycle/LogMountedParent.vue';
 import LogMounted from '../../resources/components/lifecycle/LogMounted.vue';
+import Global from '../../resources/components/slots/Global.vue';
 
 describe('shallow', () => {
   it('returns mounted wrapper with stubbed components', () => {
@@ -49,6 +50,22 @@ describe('shallow', () => {
   it('returns wrapper that you can test props of', () => {
     const wrapper = shallow(ChildProps);
     expect(wrapper.find(Submit)[0].vm.$props.hello).to.equal('hello');
+  });
+
+  it('renders default slot in global components', () => {
+    const wrapper = shallow(Global, {
+      renderDefaultSlot: true,
+    });
+    const container = wrapper.first('#container');
+    expect(container.text()).to.equal('HELLO');
+  });
+
+  it('does not render default slot in global components', () => {
+    const wrapper = shallow(Global, {
+      renderDefaultSlot: false,
+    });
+    const container = wrapper.first('#container');
+    expect(container.text()).to.equal('');
   });
 });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -68,6 +68,7 @@ interface MountOptions<V extends Vue> extends ComponentOptions<V> {
     slots?: Slots;
     globals?: object;
     instance?: typeof Vue;
+    renderDefaultSlot?: boolean;
 }
 
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -72,6 +72,7 @@ interface MountOptions<V extends Vue> extends ComponentOptions<V> {
 }
 
 
+export declare function shallow<V extends Vue, Ctor extends VueClass<V> = VueClass<V>>(component: Ctor, options?: MountOptions<Vue>): Wrapper;
 export declare function mount<V extends Vue, Ctor extends VueClass<V> = VueClass<V>>(component: Ctor, options?: MountOptions<Vue>): Wrapper;
 export declare function mount<V extends Vue>(component: ComponentOptions<V>, options?: MountOptions<Vue>): Wrapper;
 export declare function mount(component: FunctionalComponentOptions, options?: MountOptions<Vue>): Wrapper;

--- a/types/test/mount.spec.ts
+++ b/types/test/mount.spec.ts
@@ -23,12 +23,12 @@ mount<ClassComponent>(ClassComponent, {
         $store: store,
     },
     instance: localVue,
+    renderDefaultSlot: true,
     slots: {
         bar: slotWrapper,
         default: ClassComponent,
         foo: [ClassComponent],
     },
-    renderDefaultSlot: true,
 });
 
 mount(functionalOptions, {

--- a/types/test/mount.spec.ts
+++ b/types/test/mount.spec.ts
@@ -1,6 +1,6 @@
 import Vue from "vue";
 import Vuex from "vuex";
-import { mount } from "../";
+import { mount, shallow } from "../";
 import { ClassComponent, functionalOptions } from "./resources";
 
 /**
@@ -23,12 +23,15 @@ mount<ClassComponent>(ClassComponent, {
         $store: store,
     },
     instance: localVue,
-    renderDefaultSlot: true,
     slots: {
         bar: slotWrapper,
         default: ClassComponent,
         foo: [ClassComponent],
     },
+});
+
+shallow<ClassComponent>(ClassComponent, {
+    renderDefaultSlot: true,
 });
 
 mount(functionalOptions, {

--- a/types/test/mount.spec.ts
+++ b/types/test/mount.spec.ts
@@ -28,6 +28,7 @@ mount<ClassComponent>(ClassComponent, {
         default: ClassComponent,
         foo: [ClassComponent],
     },
+    renderDefaultSlot: true,
 });
 
 mount(functionalOptions, {


### PR DESCRIPTION
In the case we want to assert that a child component has been rendered inside a global component
```js
<global-component>
       <child-component></child-component>
</global-component>
```
We can pass the option `renderDefaultSlot: true` to shallow.

I don't know if it is also useful in local components.
