### PR TITLE
FIX isEmpty returns true if elements children are all comments

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -303,12 +303,13 @@ export default class Wrapper implements WrapperInterface {
   }
 
   /**
-   * Checks if node is empty
+   * Checks if node is empty or all children are comment nodes
    *
    * @returns {Boolean}
    */
   isEmpty() {
-    return this.vNode.children === undefined || this.vNode.children.length === 0;
+    return this.vNode.children === undefined || this.vNode.children.length === 0 ||
+      this.vNode.children.every(child => child.elm.nodeName === '#comment');
   }
 
   /**

--- a/test/unit/specs/wrapper/isEmpty.spec.js
+++ b/test/unit/specs/wrapper/isEmpty.spec.js
@@ -9,15 +9,36 @@ describe('isEmpty', () => {
     expect(wrapper.isEmpty()).to.equal(true);
   });
 
-  it('returns true contains empty slot', () => {
+  it('returns true if node has whitespace', () => {
+    const compiled = compileToFunctions('<div>  </div>');
+    const wrapper = mount(compiled);
+
+    expect(wrapper.isEmpty()).to.equal(true);
+  });
+
+  it('returns true if node contains removed element', () => {
+    const compiled = compileToFunctions('<div><p v-if="false"></p></div>');
+    const wrapper = mount(compiled);
+
+    expect(wrapper.isEmpty()).to.equal(true);
+  });
+
+  it('returns true if node contains empty slot', () => {
     const compiled = compileToFunctions('<div><slot></slot></div>');
     const wrapper = mount(compiled);
 
     expect(wrapper.isEmpty()).to.equal(true);
   });
 
-  it('returns false if node contains other nodes', () => {
+  it('returns false if node contains element nodes', () => {
     const compiled = compileToFunctions('<div><p /></div>');
+    const wrapper = mount(compiled);
+
+    expect(wrapper.isEmpty()).to.equal(false);
+  });
+
+  it('returns false if node contains text nodes', () => {
+    const compiled = compileToFunctions('<div>Text content</div>');
     const wrapper = mount(compiled);
 
     expect(wrapper.isEmpty()).to.equal(false);


### PR DESCRIPTION
Extension from [previous PR](https://github.com/eddyerburgh/avoriaz/pull/128) to check children are all comments when evaluating isEmpty(). 

FYI running `npm run test` failed on TSLint:
```
> avoriaz@4.2.0 lint:ts C:\dev\personal-dev\avoriaz
> tslint -c tslint.json types/**/*.ts


ERROR: types/index.d.ts[60, 5]: All 'update' signatures should be adjacent
ERROR: types/index.d.ts[16, 11]: interface name must start with a capitalized I
ERROR: types/index.d.ts[31, 11]: interface name must start with a capitalized I
ERROR: types/index.d.ts[64, 11]: interface name must start with a capitalized I
ERROR: types/index.d.ts[75, 1]: Exceeds maximum line length of 120
ERROR: types/index.d.ts[76, 1]: Exceeds maximum line length of 120
```
Seems like a pre-existing issue in the TS files, haven't touched them but can correct if you'd prefer the tests to pass (I did manually run test:karma and test:unit though and everything was green). 