### PR TITLE
[#155] Correct error message for non-string passed to hasStyle

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -223,7 +223,7 @@ export default class Wrapper implements WrapperInterface {
     }
 
     if (typeof value !== 'string') {
-      error('wrapper.hasClass() must be passed value as string');
+      error('wrapper.hasStyle() must be passed value as string');
     }
 
     /* istanbul ignore next */

--- a/test/unit/specs/wrapper/hasStyle.spec.js
+++ b/test/unit/specs/wrapper/hasStyle.spec.js
@@ -47,7 +47,7 @@ describe('hasStyle', () => {
   it('throws an error if value is not a string', () => {
     const compiled = compileToFunctions('<div />');
     const wrapper = mount(compiled);
-    const message = 'wrapper.hasClass() must be passed value as string';
+    const message = 'wrapper.hasStyle() must be passed value as string';
     expect(() => wrapper.hasStyle('color', undefined)).to.throw(Error, message);
   });
 });


### PR DESCRIPTION
FIxes https://github.com/eddyerburgh/avoriaz/issues/155

Error message for non-string passed to `hasStyle` is incorrect. Made me rather confused for a bit.