### PR TITLE
Please highlight that this library is not active

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# Note: This library is obsolete. Use [vue-test-utils](https://github.com/vuejs/vue-test-utils). 
 # avoriaz [![Build Status](https://travis-ci.org/eddyerburgh/avoriaz.svg?branch=master)](https://travis-ci.org/eddyerburgh/avoriaz)
 
 


### PR DESCRIPTION
I was comparing this library with vue-test-utils and decide on which one to use. Then I stumbled upon https://github.com/vuejs/vue-test-utils/issues/89 which clarified that way forward is vue-test-utils.