### PR TITLE
Not throw an error if element.className is SVGAnimatedString

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -207,13 +207,7 @@ export default class Wrapper implements WrapperInterface {
       error('wrapper.hasClass() must be passed a string');
     }
 
-    let classes = this.element.className;
-
-    if (typeof classes === 'object') {
-      classes = classes.baseVal;
-    }
-
-    return classes.split(' ').indexOf(className) !== -1;
+    return this.element.classList.contains(className);
   }
 
   /**

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -207,7 +207,13 @@ export default class Wrapper implements WrapperInterface {
       error('wrapper.hasClass() must be passed a string');
     }
 
-    return this.element.className.split(' ').indexOf(className) !== -1;
+    let classes = this.element.className;
+
+    if (typeof classes === 'object') {
+      classes = classes.baseVal;
+    }
+
+    return classes.split(' ').indexOf(className) !== -1;
   }
 
   /**

--- a/test/resources/components/svg-component/SvgComponent.vue
+++ b/test/resources/components/svg-component/SvgComponent.vue
@@ -1,0 +1,3 @@
+<template>
+  <svg class="svg-mock"></svg>
+</template>

--- a/test/unit/specs/wrapper/hasClass.spec.js
+++ b/test/unit/specs/wrapper/hasClass.spec.js
@@ -1,5 +1,6 @@
 import mount from '../../../../src/mount';
 import Form from '../../../resources/components/form/Form.vue';
+import SvgComponent from '../../../resources/components/svg-component/SvgComponent.vue';
 
 describe('hasClass', () => {
   it('returns true if wrapper has class name', () => {
@@ -21,5 +22,12 @@ describe('hasClass', () => {
       const message = 'wrapper.hasClass() must be passed a string';
       expect(() => wrapper.hasClass(invalidSelector)).to.throw(Error, message);
     });
+  });
+
+  it('not throw an error if element.className is SVGAnimatedString', () => {
+    const wrapper = mount(SvgComponent);
+
+    expect(() => wrapper.hasClass('svg-mock')).not.throw();
+    expect(wrapper.hasClass('svg-mock')).to.equal(true);
   });
 });


### PR DESCRIPTION
Got the error `undefined is not an object`, when try to use `hasClass` on `svg` elements.
Enzyme has similar error [here](https://github.com/airbnb/enzyme/pull/448), from there I took these changes.